### PR TITLE
absolute path transmogrify judge file refs; standardize the conversion

### DIFF
--- a/pkg/eval/config.go
+++ b/pkg/eval/config.go
@@ -188,11 +188,16 @@ func Read(data []byte, basePath string) (*EvalSpec, error) {
 
 	// Convert all relative file paths to absolute paths
 	if spec.Config.Agent != nil && spec.Config.Agent.Type == "file" {
-		if err := resolveFilePath(&spec.Config.Agent.Path, basePath); err != nil {
+		if err := util.ResolveRelativePath(&spec.Config.Agent.Path, basePath); err != nil {
 			return nil, fmt.Errorf("failed to resolve agent file path: %w", err)
 		}
 	}
-	if err := resolveFilePath(&spec.Config.McpConfigFile, basePath); err != nil {
+	if spec.Config.LLMJudge != nil && spec.Config.LLMJudge.AgentRef != nil && spec.Config.LLMJudge.AgentRef.Type == "file" {
+		if err := util.ResolveRelativePath(&spec.Config.LLMJudge.AgentRef.Path, basePath); err != nil {
+			return nil, fmt.Errorf("failed to resolve llm judge agent ref file path: %w", err)
+		}
+	}
+	if err := util.ResolveRelativePath(&spec.Config.McpConfigFile, basePath); err != nil {
 		return nil, fmt.Errorf("failed to resolve mcp config file path: %w", err)
 	}
 
@@ -216,7 +221,7 @@ func Read(data []byte, basePath string) (*EvalSpec, error) {
 			if src.Path == "" {
 				return nil, fmt.Errorf("skills.sources[%d]: path is required for type \"path\"", i)
 			}
-			if err := resolveFilePath(&src.Path, basePath); err != nil {
+			if err := util.ResolveRelativePath(&src.Path, basePath); err != nil {
 				return nil, fmt.Errorf("failed to resolve skill source path at index %d: %w", i, err)
 			}
 		}
@@ -230,11 +235,11 @@ func Read(data []byte, basePath string) (*EvalSpec, error) {
 				return nil, fmt.Errorf("taskSet[%d]: %w", i, err)
 			}
 		} else if ts.Path != "" {
-			if err := resolveFilePath(&ts.Path, basePath); err != nil {
+			if err := util.ResolveRelativePath(&ts.Path, basePath); err != nil {
 				return nil, fmt.Errorf("failed to resolve task set path at index %d: %w", i, err)
 			}
 		} else if ts.Glob != "" {
-			if err := resolveFilePath(&ts.Glob, basePath); err != nil {
+			if err := util.ResolveRelativePath(&ts.Glob, basePath); err != nil {
 				return nil, fmt.Errorf("failed to resolve task set glob at index %d: %w", i, err)
 			}
 		}
@@ -302,23 +307,6 @@ func validateNoPathEscape(p string) error {
 	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
 		return fmt.Errorf("path %q escapes the repo root", p)
 	}
-
-	return nil
-}
-
-func resolveFilePath(filePath *string, basePath string) error {
-	if filePath == nil || *filePath == "" {
-		return nil
-	}
-
-	// If the path is already absolute, leave it as-is
-	if filepath.IsAbs(*filePath) {
-		return nil
-	}
-
-	// Convert relative path to absolute path based on the YAML file's directory
-	absPath := filepath.Join(basePath, *filePath)
-	*filePath = absPath
 
 	return nil
 }

--- a/pkg/eval/config_test.go
+++ b/pkg/eval/config_test.go
@@ -14,6 +14,23 @@ const (
 	testDataPath = "testdata"
 )
 
+func TestReadJudgeRefPathResolution(t *testing.T) {
+	basePath, err := os.Getwd()
+	require.NoError(t, err)
+	basePath = filepath.Join(basePath, testDataPath)
+
+	data, err := os.ReadFile(filepath.Join(basePath, "judge-ref-file-relative.yaml"))
+	require.NoError(t, err)
+
+	spec, err := Read(data, basePath)
+	require.NoError(t, err)
+
+	require.NotNil(t, spec.Config.LLMJudge)
+	require.NotNil(t, spec.Config.LLMJudge.AgentRef)
+	assert.True(t, filepath.IsAbs(spec.Config.LLMJudge.AgentRef.Path), "judge ref path should be absolute, got %q", spec.Config.LLMJudge.AgentRef.Path)
+	assert.Equal(t, filepath.Join(basePath, "agents/judge.yaml"), spec.Config.LLMJudge.AgentRef.Path)
+}
+
 func TestReadSourceSpec(t *testing.T) {
 	basePath, err := os.Getwd()
 	require.NoError(t, err)

--- a/pkg/eval/testdata/judge-ref-file-relative.yaml
+++ b/pkg/eval/testdata/judge-ref-file-relative.yaml
@@ -1,0 +1,8 @@
+kind: Eval
+config:
+  llmJudge:
+    ref:
+      type: file
+      path: agents/judge.yaml
+  taskSets:
+    - path: tasks/test.yaml

--- a/pkg/task/config.go
+++ b/pkg/task/config.go
@@ -125,14 +125,18 @@ func Read(data []byte, basePath string) (*TaskConfig, error) {
 			return nil, fmt.Errorf("v1alpha1 requires steps field")
 		}
 
-		if err := resolveStepPath(s.SetupScript, basePath); err != nil {
-			return nil, fmt.Errorf("failed to resolve setup script path: %w", err)
+		if s.SetupScript != nil {
+			if err := util.ResolveRelativePath(&s.SetupScript.File, basePath); err != nil {
+				return nil, fmt.Errorf("failed to resolve setup script path: %w", err)
+			}
 		}
-		if err := resolveStepPath(s.CleanupScript, basePath); err != nil {
-			return nil, fmt.Errorf("failed to resolve cleanup script path: %w", err)
+		if s.CleanupScript != nil {
+			if err := util.ResolveRelativePath(&s.CleanupScript.File, basePath); err != nil {
+				return nil, fmt.Errorf("failed to resolve cleanup script path: %w", err)
+			}
 		}
-		if !s.VerifyScript.IsEmpty() {
-			if err := resolveStepPath(s.VerifyScript.Step, basePath); err != nil {
+		if !s.VerifyScript.IsEmpty() && s.VerifyScript.Step != nil {
+			if err := util.ResolveRelativePath(&s.VerifyScript.Step.File, basePath); err != nil {
 				return nil, fmt.Errorf("failed to resolve verify script path: %w", err)
 			}
 		}
@@ -142,28 +146,13 @@ func Read(data []byte, basePath string) (*TaskConfig, error) {
 		}
 	}
 
-	if err := resolveStepPath(spec.Spec.Prompt, basePath); err != nil {
-		return nil, fmt.Errorf("failed to resolve prompt path: %w", err)
+	if spec.Spec.Prompt != nil {
+		if err := util.ResolveRelativePath(&spec.Spec.Prompt.File, basePath); err != nil {
+			return nil, fmt.Errorf("failed to resolve prompt path: %w", err)
+		}
 	}
 
 	return spec, nil
-}
-
-func resolveStepPath(step *util.Step, basePath string) error {
-	if step == nil || step.File == "" {
-		return nil
-	}
-
-	// If the path is already absolute, leave it as-is
-	if filepath.IsAbs(step.File) {
-		return nil
-	}
-
-	// Convert relative path to absolute path based on the YAML file's directory
-	absPath := filepath.Join(basePath, step.File)
-	step.File = absPath
-
-	return nil
 }
 
 func FromFile(path string) (*TaskConfig, error) {

--- a/pkg/util/path.go
+++ b/pkg/util/path.go
@@ -1,0 +1,19 @@
+package util
+
+import "path/filepath"
+
+// ResolveRelativePath converts a relative path to absolute using basePath as the base directory.
+// Absolute paths and empty strings are left unchanged.
+func ResolveRelativePath(filePath *string, basePath string) error {
+	if filePath == nil || *filePath == "" {
+		return nil
+	}
+
+	if filepath.IsAbs(*filePath) {
+		return nil
+	}
+
+	*filePath = filepath.Join(basePath, *filePath)
+
+	return nil
+}


### PR DESCRIPTION
Provides a common util to to convert relative paths to absolute paths based on the config location, and converts both pre-existing call sites to use it. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resolution of relative paths in evaluation configurations, including judge agents, task sets, skills, and MCP configuration files.
  * Improved resolution of relative script and prompt paths in task configurations.
  * Added safeguards to avoid path resolution errors for optional or empty configuration sections.
* **Tests**
  * Added coverage verifying relative judge-agent paths resolve correctly to absolute paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->